### PR TITLE
remove python linting

### DIFF
--- a/.github/workflows/fastAPI.yml
+++ b/.github/workflows/fastAPI.yml
@@ -28,9 +28,9 @@ jobs:
         python -m pip install black==23.3.0
         pip install -r requirements.txt
       timeout-minutes: 5
-    - name: Lint with black
-      run: black . && black --check .
-      timeout-minutes: 5
+    #- name: Lint with black
+    # run: black . && black --check .
+    # timeout-minutes: 5
     - name: Run Tests with Pytest
       run: |
         python -m pytest ./tests


### PR DESCRIPTION
Type incompatibility between python 3.10 and lint library black